### PR TITLE
Add Makefile for Building and Installing CExpress as a Shared Library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+CC = gcc
+CFLAGS = -Wall -fPIC -Iinclude
+LDFLAGS = -shared
+SRC = $(wildcard src/*.c)
+OBJ = $(SRC:.c=.o)
+TARGET = libCExpress.dylib
+
+PREFIX ?= /usr/local
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+    $(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c
+    $(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+    rm -f src/*.o $(TARGET)
+
+install: $(TARGET)
+    mkdir -p $(PREFIX)/lib
+    mkdir -p $(PREFIX)/include/CExpress
+    cp $(TARGET) $(PREFIX)/lib/
+    cp include/CExpress/*.h $(PREFIX)/include/CExpress/

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,21 @@ PREFIX ?= /usr/local
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-    $(CC) $(LDFLAGS) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^
 
 %.o: %.c
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-    rm -f src/*.o $(TARGET)
+	rm -f src/*.o $(TARGET)
 
 install: $(TARGET)
-    mkdir -p $(PREFIX)/lib
-    mkdir -p $(PREFIX)/include/CExpress
-    cp $(TARGET) $(PREFIX)/lib/
-    cp include/CExpress/*.h $(PREFIX)/include/CExpress/
+	mkdir -p $(PREFIX)/lib
+	mkdir -p $(PREFIX)/include/CExpress
+	cp $(TARGET) $(PREFIX)/lib/
+	cp include/CExpress/*.h $(PREFIX)/include/CExpress/
+
+uninstall:
+	rm -f $(PREFIX)/lib/$(TARGET)
+	rm -rf $(PREFIX)/include/CExpress
+	rm -f libCExpress.dylib

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -67,7 +67,7 @@ Removes a route from the server.
 ## Usage
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 
 char *hello_handler(void) {
     char *response = malloc(50);

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -25,7 +25,7 @@ Perfect for microservices, APIs, static file serving, and rapid prototyping with
 ## Quick Example
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -22,7 +22,7 @@ CExpress can be installed as a shared C library on your system, making it easy t
 2. **Build and Install the library and headers:**
 
    ```bash
-   sudo make install
+   make install
    ```
 
    This will:
@@ -46,6 +46,14 @@ gcc yourfile.c -lCExpress
 ## Uninstall
 
 To remove CExpress, delete the installed files:
+
+### Option 1:
+
+```bash
+make uninstall
+```
+
+### Option 2:
 
 ```bash
 sudo rm /usr/local/lib/libCExpress.dylib

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,3 +1,64 @@
 # Installation
 
-To be added! Currently in the process of uploading to homebrew. Will add instructions shortly :)
+CExpress can be installed as a shared C library on your system, making it easy to include and link in your own C projects.
+
+## Prerequisites
+
+- GCC or Clang compiler
+- Make utility
+- macOS or Linux (for Windows, manual steps may differ)
+
+## Build and Install
+
+### Option 1: Install through MakeFile
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/Karl-Michaud/CExpress.git
+   cd CExpress
+   ```
+
+2. **Build and Install the library and headers:**
+
+   ```bash
+   sudo make install
+   ```
+
+   This will:
+   - Copy the shared library (`libCExpress.dylib` on macOS, or `libCExpress.so` on Linux) to `/usr/local/lib/`
+   - Copy the header files to `/usr/local/include/CExpress/`
+
+## Usage in Your Project
+
+After installation, you can include CExpress in your C code:
+
+```c
+#include <CExpress/server.h>
+```
+
+And compile your project with:
+
+```bash
+gcc yourfile.c -lCExpress
+```
+
+## Uninstall
+
+To remove CExpress, delete the installed files:
+
+```bash
+sudo rm /usr/local/lib/libCExpress.dylib
+sudo rm -r /usr/local/include/CExpress/
+```
+
+## Notes
+
+- If you want to install to a different location, set the `PREFIX` variable:
+  ```bash
+  sudo make install PREFIX=/custom/path
+  ```
+- For Linux, you may want to change the library extension in the Makefile from `.dylib` to `.so`.
+
+---
+Now you are ready to use CExpress in your C projects!

--- a/docs/docs/usage-examples.md
+++ b/docs/docs/usage-examples.md
@@ -10,7 +10,7 @@
 ## Basic Hello World
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,7 +51,7 @@ int main(void) {
 ## JSON API
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -124,7 +124,7 @@ int main(void) {
 ## Static Files
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -198,7 +198,7 @@ int main(void) {
 ## REST API
 
 ```c
-#include "include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/basic_hello_world.c
+++ b/examples/basic_hello_world.c
@@ -13,7 +13,7 @@
  * @date 2025-01-27
  */
 
-#include "../include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/json_api.c
+++ b/examples/json_api.c
@@ -19,7 +19,7 @@
  * @date 2025-01-27
  */
 
-#include "../include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/rest_api.c
+++ b/examples/rest_api.c
@@ -27,7 +27,7 @@
  * @date 2025-01-27
  */
 
-#include "../include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/static_files.c
+++ b/examples/static_files.c
@@ -20,7 +20,7 @@
  * @date 2025-01-27
  */
 
-#include "../include/CExpress/server.h"
+#include <CExpress/server.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This PR introduces a Makefile that automates building CExpress as a shared library (`libCExpress.dylib`), installing headers and the library to system directories, and uninstalling them.

- Enables easy compilation and installation with `make install`
- Adds uninstall and delete targets for clean removal
- Updates installation documentation to reflect Makefile usage
- Simplifies integration: users only need to `#include <CExpress/server.h>` and link with `-lCExpress` flag

This streamlines the process for users to build, install, and use CExpress as a shared C library.